### PR TITLE
feat(snap): use updated environment variable injection

### DIFF
--- a/snap/local/hooks/cmd/configure/configure.go
+++ b/snap/local/hooks/cmd/configure/configure.go
@@ -24,6 +24,8 @@ import (
 	"strings"
 
 	hooks "github.com/canonical/edgex-snap-hooks/v2"
+	"github.com/canonical/edgex-snap-hooks/v2/log"
+	"github.com/canonical/edgex-snap-hooks/v2/options"
 	local "github.com/edgexfoundry/device-gpio-go/hooks"
 )
 
@@ -97,6 +99,12 @@ func main() {
 		// no action necessary
 	default:
 		hooks.Error(fmt.Sprintf("Invalid value for 'autostart' : %s", autostart))
+		os.Exit(1)
+	}
+
+	log.SetComponentName("configure")
+	if err := options.ProcessAppConfig("device-gpio"); err != nil {
+		hooks.Error(fmt.Sprintf("could not process options: %v", err))
 		os.Exit(1)
 	}
 }

--- a/snap/local/hooks/go.mod
+++ b/snap/local/hooks/go.mod
@@ -1,5 +1,5 @@
 module github.com/edgexfoundry/device-gpio-go/hooks
 
-require github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.2.0.20220420075917-7fdbcd41ba0b
+require github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.3
 
 go 1.16

--- a/snap/local/hooks/go.mod
+++ b/snap/local/hooks/go.mod
@@ -1,5 +1,5 @@
 module github.com/edgexfoundry/device-gpio-go/hooks
 
-require github.com/canonical/edgex-snap-hooks/v2 v2.0.3
+require github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.2.0.20220420075917-7fdbcd41ba0b
 
 go 1.16

--- a/snap/local/hooks/go.mod
+++ b/snap/local/hooks/go.mod
@@ -1,5 +1,5 @@
 module github.com/edgexfoundry/device-gpio-go/hooks
 
-require github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.3
+require github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.5
 
 go 1.16

--- a/snap/local/hooks/go.sum
+++ b/snap/local/hooks/go.sum
@@ -1,5 +1,5 @@
-github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.3 h1:kQ7tGjA7k6iAfsvLRKpdoLy0zwsG+4Wqn3DNkbJrhZ8=
-github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.3/go.mod h1:rOxrwdYL7hJDhxFH3uV+nVgLPjWOhJWgM5PRD5YG1jI=
+github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.5 h1:EDFjmHy8CG4T8uFPqD+Per8Hgk250PvRsMgEDCXjYtE=
+github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.5/go.mod h1:rOxrwdYL7hJDhxFH3uV+nVgLPjWOhJWgM5PRD5YG1jI=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/snap/local/hooks/go.sum
+++ b/snap/local/hooks/go.sum
@@ -1,0 +1,12 @@
+github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.2.0.20220420075917-7fdbcd41ba0b h1:vKrKzgdZo3kk0mptvQ1vvUUUQ2eYjE+nDMhT2tC9UJw=
+github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.2.0.20220420075917-7fdbcd41ba0b/go.mod h1:rOxrwdYL7hJDhxFH3uV+nVgLPjWOhJWgM5PRD5YG1jI=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/snap/local/hooks/go.sum
+++ b/snap/local/hooks/go.sum
@@ -1,5 +1,5 @@
-github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.2.0.20220420075917-7fdbcd41ba0b h1:vKrKzgdZo3kk0mptvQ1vvUUUQ2eYjE+nDMhT2tC9UJw=
-github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.2.0.20220420075917-7fdbcd41ba0b/go.mod h1:rOxrwdYL7hJDhxFH3uV+nVgLPjWOhJWgM5PRD5YG1jI=
+github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.3 h1:kQ7tGjA7k6iAfsvLRKpdoLy0zwsG+4Wqn3DNkbJrhZ8=
+github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.3/go.mod h1:rOxrwdYL7hJDhxFH3uV+nVgLPjWOhJWgM5PRD5YG1jI=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
For details on the new scheme for setting environment variables, please refer to https://github.com/edgexfoundry/edgex-go/pull/3986.
Signed-off-by: Mengyi Wang <mengyi.wang@canonical.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-gpio/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-gpio/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?) N/A - they are in the imported module https://github.com/canonical/edgex-snap-testing/pull/53
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. Set up:
```
snap install edgexfoundry --edge
snap install edgex-device-gpio --channel=edge/pr-25
```
2. Enable config and set a global config value:
```
$ snap set edgex-device-gpio config-enabled=true
$ snap set edgex-device-gpio config.service-startupmsg="testing injection"
$ snap start edgex-device-gpio
Started.

$ snap logs -n=all edgex-device-gpio | grep "testing"
2022-04-26T10:49:02+02:00 edgex-device-gpio.device-gpio[1745709]: level=INFO ts=2022-04-26T08:49:02.091648727Z app=device-gpio source=variables.go:352 msg="Variables override of 'Service.StartupMsg' by environment variable: SERVICE_STARTUPMSG=testing injection"
2022-04-26T10:49:02+02:00 edgex-device-gpio.device-gpio[1745709]: level=INFO ts=2022-04-26T08:49:02.102824925Z app=device-gpio source=message.go:55 msg="testing injection"
```
3. Set a app-specific value:
```
$ snap set edgex-device-gpio apps.device-gpio.config.service-port=11111
$ snap restart edgex-device-gpio
Restarted.

$ snap logs -n=all edgex-device-gpio | grep "11111"
2022-04-22T11:47:19+02:00 edgex-device-gpio.device-gpio[1257533]: level=INFO ts=2022-04-22T09:47:19.125348038Z app=device-gpio source=variables.go:352 msg="Variables override of 'Service.Port' by environment variable: SERVICE_PORT=11111"
2022-04-22T11:47:19+02:00 edgex-device-gpio.device-gpio[1257533]: level=INFO ts=2022-04-22T09:47:19.126726662Z app=device-gpio source=httpserver.go:123 msg="Web server starting (localhost:11111)"
```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->