### PR TITLE
docs: correct release name, remove build items from features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - [go-mod-secrets](https://github.com/edgexfoundry/go-mod-secrets/blob/main/CHANGELOG.md) (indirect dependency)
 - [go-mod-configuration](https://github.com/edgexfoundry/go-mod-configuration/blob/main/CHANGELOG.md) (indirect dependency)
 
-## [v2.2.0] - Jakarta - 2022-05-11 - (Only compatible with the 2.x releases)
+## [v2.2.0] - Kamakura - 2022-05-11 - (Only compatible with the 2.x releases)
 ### Documentation 📖
 - **snap:** Move usage instructions to docs ([#27](https://github.com/edgexfoundry/device-gpio/issues/27)) ([#9aa390b](https://github.com/edgexfoundry/device-gpio/commits/9aa390b))
 
@@ -18,10 +18,8 @@
 ### Features ✨
 - Enable security hardening ([#99940ec](https://github.com/edgexfoundry/device-gpio/commits/99940ec))
 - **api:** Upgrade to v2 API ([#427c9ef](https://github.com/edgexfoundry/device-gpio/commits/427c9ef))
-- **snap:** Bump edgex-snap-hooks to v2.2.0-beta.3 ([#849856e](https://github.com/edgexfoundry/device-gpio/commits/849856e))
 - **snap:** Use updated environment variable injection ([#1b28166](https://github.com/edgexfoundry/device-gpio/commits/1b28166))
 - **snap:** Snap packaging ([#13](https://github.com/edgexfoundry/device-gpio/issues/13)) ([#7aa6e8d](https://github.com/edgexfoundry/device-gpio/commits/7aa6e8d))
-- **snap:** Bump edgex-snap-hooks to v2.2.0-beta.5 ([#55ae9f2](https://github.com/edgexfoundry/device-gpio/commits/55ae9f2))
 
 ### Bug Fixes 🐛
 - Remove set of direction of a get GPIO or read ([#24](https://github.com/edgexfoundry/device-gpio/issues/24)) ([#b9afc87](https://github.com/edgexfoundry/device-gpio/commits/b9afc87))


### PR DESCRIPTION
- Correct release name to Kamakura.
- Remove build changes, falsely classified as feat in PRs
 
Signed-off-by: Farshid Tavakolizadeh <farshid.tavakolizadeh@canonical.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-gpio/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-gpio/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->