### PR TITLE
feat!: Remove ZeroMQ MessageBus capability

### DIFF
--- a/Attribution.txt
+++ b/Attribution.txt
@@ -171,9 +171,6 @@ https://github.com/warthog618/gpiod/blob/master/LICENSES/MIT.txt
 eclipse/paho.mqtt.golang (Eclipse Public License 2.0) https://github.com/eclipse/paho.mqtt.golang
 https://github.com/eclipse/paho.mqtt.golang/blob/master/LICENSE
 
-pebbe/zmq4 (BSD-2) https://github.com/pebbe/zmq4
-https://github.com/pebbe/zmq4/blob/master/LICENSE.txt
-
 gopkg.in/yaml v2 (Apache 2.0) https://github.com/go-yaml/yaml/tree/v2
 https://github.com/go-yaml/yaml/blob/v2/LICENSE
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ FROM ${BASE} AS builder
 ARG ADD_BUILD_TAGS=""
 ARG MAKE="make -e ADD_BUILD_TAGS=$ADD_BUILD_TAGS build"
 
-ARG ALPINE_PKG_BASE="make git openssh-client gcc libc-dev zeromq-dev libsodium-dev"
+ARG ALPINE_PKG_BASE="make git openssh-client "
 ARG ALPINE_PKG_EXTRA=""
 
 # set the working directory
@@ -41,7 +41,7 @@ FROM alpine:3.16
 LABEL license='SPDX-License-Identifier: Apache-2.0' \
   copyright='Copyright (c) 2021: Jiangxing Intelligence'
 
-RUN apk add --update --no-cache zeromq
+RUN apk add --update --no-cache
 
 WORKDIR /
 COPY --from=builder /device-gpio/Attribution.txt /

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,5 @@
 .PHONY: build test unittest lint clean prepare update docker
 
-GO = CGO_ENABLED=0 GO111MODULE=on go
-GOCGO=CGO_ENABLED=1 GO111MODULE=on go
-
-# see https://shibumi.dev/posts/hardening-executables
-CGO_CPPFLAGS="-D_FORTIFY_SOURCE=2"
-CGO_CFLAGS="-O2 -pipe -fno-plt"
-CGO_CXXFLAGS="-O2 -pipe -fno-plt"
-CGO_LDFLAGS="-Wl,-O1,–sort-common,–as-needed,-z,relro,-z,now"
-
 MICROSERVICES=cmd/device-gpio
 
 .PHONY: $(MICROSERVICES)
@@ -22,7 +13,6 @@ VERSION=$(shell cat ./VERSION 2>/dev/null || echo 0.0.0)
 GIT_SHA=$(shell git rev-parse HEAD)
 
 GOFLAGS=-ldflags "-X github.com/edgexfoundry/device-gpio.Version=$(VERSION)" -trimpath -mod=readonly
-CGOFLAGS=-ldflags "-linkmode=external -X github.com/edgexfoundry/device-gpio.Version=$(VERSION)" -trimpath -mod=readonly -buildmode=pie
 
 build: $(MICROSERVICES)
 
@@ -33,17 +23,17 @@ tidy:
 	go mod tidy
 
 cmd/device-gpio:
-	$(GOCGO) build -tags "$(ADD_BUILD_TAGS)" $(CGOFLAGS) -o $@ ./cmd
+	CGO_ENABLED=0 go build -tags "$(ADD_BUILD_TAGS)" $(CGOFLAGS) -o $@ ./cmd
 
 unittest:
-	$(GOCGO) test ./... -coverprofile=coverage.out ./...
+	go test ./... -coverprofile=coverage.out ./...
 
 lint:
 	@which golangci-lint >/dev/null || echo "WARNING: go linter not installed. To install, run\n  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b \$$(go env GOPATH)/bin v1.46.2"
 	@if [ "z${ARCH}" = "zx86_64" ] && which golangci-lint >/dev/null ; then golangci-lint run --config .golangci.yml ; else echo "WARNING: Linting skipped (not on x86_64 or linter not installed)"; fi
 
 test: unittest lint
-	$(GOCGO) vet ./...
+	go vet ./...
 	gofmt -l $$(find . -type f -name '*.go'| grep -v "/vendor/")
 	[ "`gofmt -l $$(find . -type f -name '*.go'| grep -v "/vendor/")`" = "" ]
 	./bin/test-attribution-txt.sh
@@ -65,4 +55,4 @@ docker-nats:
 	make -e ADD_BUILD_TAGS=include_nats_messaging docker
 
 vendor:
-	$(GO) mod vendor
+	CGO_ENABLED=0 go mod vendor

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/edgexfoundry/device-gpio
 go 1.18
 
 require (
-	github.com/edgexfoundry/device-sdk-go/v3 v3.0.0-dev.5
+	github.com/edgexfoundry/device-sdk-go/v3 v3.0.0-dev.6
 	github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.2
 	github.com/spf13/cast v1.5.0
 	github.com/warthog618/gpiod v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -45,8 +45,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/eclipse/paho.mqtt.golang v1.4.2 h1:66wOzfUHSSI1zamx7jR6yMEI5EuHnT1G6rNA5PM12m4=
 github.com/eclipse/paho.mqtt.golang v1.4.2/go.mod h1:JGt0RsEwEX+Xa/agj90YJ9d9DH2b7upDZMK9HRbFvCA=
-github.com/edgexfoundry/device-sdk-go/v3 v3.0.0-dev.5 h1:8jvPXdI06yGOH3qw3BgN/xutHVoAgUU+Q946rc89C9w=
-github.com/edgexfoundry/device-sdk-go/v3 v3.0.0-dev.5/go.mod h1:9tfeovR5aXyNb4/kB6ymWvwFUYABvjt9vy3UPyEN6qg=
+github.com/edgexfoundry/device-sdk-go/v3 v3.0.0-dev.6 h1:4hvEOdtLUjWBqvc9ZpdYLqLhrXzZRwW86RsgWJBmSkQ=
+github.com/edgexfoundry/device-sdk-go/v3 v3.0.0-dev.6/go.mod h1:9tfeovR5aXyNb4/kB6ymWvwFUYABvjt9vy3UPyEN6qg=
 github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.5 h1:3WMWQ0oi++KFrau/e8BOTqgzORCa3G7bLG0w/wO72Io=
 github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.5/go.mod h1:cGXMUtbbzw+npJpMcFHPlXIN+ZPF71aiimhJ6v8kaSc=
 github.com/edgexfoundry/go-mod-configuration/v3 v3.0.0-dev.2 h1:xp5MsP+qf/fuJxy8fT7k1N+c4j4C6w04qMCBXm6id7o=

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -62,8 +62,7 @@ parts:
     after: [metadata]
     source: .
     plugin: make
-    build-packages: [git, libzmq3-dev, pkg-config]
-    stage-packages: [libzmq5]
+    build-packages: [git, pkg-config]
     build-snaps: [go/1.18/stable]
     override-build: |
       cd $SNAPCRAFT_PART_SRC


### PR DESCRIPTION
BREAKING CHANGE: ZeroMQ MessageBus capability no longer available

Signed-off-by: Marc-Philippe Fuller <marc-philippe.fuller@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-gpio/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-gpio/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
`make docker`
`make build`
Run service locally with non-secure EdgeX stack running.
Verify bootstraps successfully

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->