### PR TITLE
build(snap): Upgrade snap base to core22, remove deprecated plug

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: edgex-device-gpio
-base: core20 
+base: core22
 license: Apache-2.0
 summary: EdgeX GPIO Device Service
 description: Refer to https://snapcraft.io/edgex-device-gpio
@@ -26,11 +26,6 @@ plugs:
     interface: content
     target: $SNAP_DATA/config/device-gpio
 
-  # deprecated
-  device-config:
-    interface: content
-    target: $SNAP_DATA/config/device-gpio
-
 apps:
   device-gpio:
     command: bin/device-gpio --configDir $SNAP_DATA/config/device-gpio/res --configProvider --registry
@@ -53,9 +48,9 @@ parts:
     plugin: make
     build-snaps: [ go/1.20/stable ]
     override-build: |
-      cd $SNAPCRAFT_PART_SRC
+      cd $CRAFT_PART_SRC
       make build
-      install -DT ./helper-go $SNAPCRAFT_PART_INSTALL/bin/helper-go
+      install -DT ./helper-go $CRAFT_PART_INSTALL/bin/helper-go
     
   device-gpio:
     source: .
@@ -63,7 +58,7 @@ parts:
     build-packages: [git]
     build-snaps: [go/1.20/stable]
     override-build: |
-      cd $SNAPCRAFT_PART_SRC
+      cd $CRAFT_PART_SRC
 
       if git describe ; then
         VERSION=$(git describe --tags --abbrev=0 | sed 's/v//')
@@ -72,22 +67,20 @@ parts:
       fi
       
       # set the version of the snap
-      snapcraftctl set-version $VERSION
+      craftctl set version=$VERSION
       
       # write version to file for the build
       echo $VERSION > VERSION
 
       make build
       
-      install -DT cmd/device-gpio $SNAPCRAFT_PART_INSTALL/bin/device-gpio
+      install -DT cmd/device-gpio $CRAFT_PART_INSTALL/bin/device-gpio
 
-      RES=$SNAPCRAFT_PART_INSTALL/config/device-gpio/res/
+      RES=$CRAFT_PART_INSTALL/config/device-gpio/res/
       mkdir -p $RES
-      cp    cmd/res/configuration.yaml $RES
-      cp -r cmd/res/devices $RES
-      cp -r cmd/res/profiles $RES
+      cp -r cmd/res/* $RES
       
-      DOC=$SNAPCRAFT_PART_INSTALL/usr/share/doc/device-gpio
+      DOC=$CRAFT_PART_INSTALL/usr/share/doc/device-gpio
       mkdir -p $DOC
       cp Attribution.txt $DOC/Attribution.txt
       cp LICENSE $DOC/LICENSE


### PR DESCRIPTION
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-gpio/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-gpio/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
Testing locally with [edgex-snap-testing suite](https://github.com/canonical/edgex-snap-testing/tree/main/test/suites/device-gpio):
```
edgex-snap-testing$ LOCAL_SNAP=~/Desktop/edgex400/device-gpio/edgex-device-gpio_3.0.0-dev.20_amd64.snap go test -v ./test/suites/device-gpio/
2023/04/24 12:45:41 [CLEAN]
2023/04/24 12:45:41 [exec] sudo snap remove --purge edgex-device-gpio
[sudo] password for mengyi: 
2023/04/24 12:45:44 [stderr] snap "edgex-device-gpio" is not installed
2023/04/24 12:45:44 [exec] sudo snap remove --purge edgexfoundry
2023/04/24 12:45:44 [stderr] snap "edgexfoundry" is not installed
2023/04/24 12:45:44 [SETUP]
2023/04/24 12:45:44 [exec] sudo snap install --dangerous /home/mengyi/Desktop/edgex400/device-gpio/edgex-device-gpio_3.0.0-dev.20_amd64.snap
2023/04/24 12:45:47 [stdout] edgex-device-gpio 3.0.0-dev.20 installed
2023/04/24 12:45:47 [exec] sudo snap install edgexfoundry --channel=latest/edge
2023/04/24 12:46:20 [stdout] edgexfoundry (edge) 3.0.0-dev.136 from Canonical** installed
2023/04/24 12:46:20 [exec] sudo snap connect edgexfoundry:edgex-secretstore-token edgex-device-gpio:edgex-secretstore-token
2023/04/24 12:46:21 Retry 1/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command), 8200 (vault), 8500 (consul), 6379 (redis), 8000 (nginx(http)), 59842 (security-proxy-auth), 8443 (nginx(https))
=== RUN   TestCommon
=== RUN   TestCommon/content_interfaces
=== RUN   TestCommon/content_interfaces/seed_secretstore_token
    exec.go:19: [exec] sudo cat /var/snap/edgexfoundry/current/secrets/device-gpio/secrets-token.json
    exec.go:19: [exec] sudo cat /var/snap/edgex-device-gpio/current/device-gpio/secrets-token.json
=== RUN   TestCommon/config
=== RUN   TestCommon/config/change_service_port
    exec.go:19: [exec] sudo snap start --enable edgex-device-gpio.device-gpio
    exec.go:101: [stdout] Started.
    net.go:144: Retry 1/60: Waiting for ports: 59910 (device-gpio)
    net.go:144: Retry 2/60: Waiting for ports: 59910 (device-gpio)
    exec.go:19: [exec] sudo snap stop --disable edgex-device-gpio.device-gpio
    exec.go:101: [stdout] 2023-04-24T12:46:24+02:00 INFO Waiting for "snap.edgex-device-gpio.device-gpio.service" to stop.
    exec.go:101: [stdout] Stopped.
=== RUN   TestCommon/config/change_service_port/app_config
    exec.go:19: [exec] sudo snap stop --disable edgex-device-gpio.device-gpio
    exec.go:101: [stdout] Stopped.
    exec.go:19: [exec] sudo lsof -nPi :22222 || true
    net.go:256: Port 22222 is available.
    exec.go:19: [exec] sudo snap set edgex-device-gpio apps.device-gpio.config.edgex-config-provider='none'
    config.go:204: Copying common config file from platform snap to service snap: edgex-device-gpio
    exec.go:19: [exec] sudo cp /snap/edgexfoundry/current/config/core-common-config-bootstrapper/res/configuration.yaml /var/snap/edgex-device-gpio/current/config/common-config.yaml
    exec.go:19: [exec] sudo snap set edgex-device-gpio apps.device-gpio.config.edgex-common-config='/var/snap/edgex-device-gpio/current/config/common-config.yaml'
    exec.go:19: [exec] sudo snap set edgex-device-gpio apps.device-gpio.config.service-port='22222'
    exec.go:19: [exec] sudo snap start --enable edgex-device-gpio.device-gpio
    exec.go:101: [stdout] Started.
    net.go:144: Retry 1/60: Waiting for ports: 22222
    net.go:144: Retry 2/60: Waiting for ports: 22222
    exec.go:19: [exec] sudo snap unset edgex-device-gpio apps.device-gpio.config.service-port
    exec.go:19: [exec] sudo snap restart edgex-device-gpio.device-gpio
    exec.go:101: [stdout] 2023-04-24T12:46:32+02:00 INFO Waiting for "snap.edgex-device-gpio.device-gpio.service" to stop.
    exec.go:101: [stdout] Restarted.
    net.go:144: Retry 1/60: Waiting for ports: 59910 (device-gpio)
    exec.go:19: [exec] sudo snap unset edgex-device-gpio apps
    exec.go:19: [exec] sudo snap stop --disable edgex-device-gpio.device-gpio
    exec.go:101: [stdout] 2023-04-24T12:46:38+02:00 INFO Waiting for "snap.edgex-device-gpio.device-gpio.service" to stop.
    exec.go:101: [stdout] Stopped.
=== RUN   TestCommon/config/change_service_port/global_config
    exec.go:19: [exec] sudo snap stop --disable edgex-device-gpio.device-gpio
    exec.go:101: [stdout] Stopped.
    exec.go:19: [exec] sudo lsof -nPi :33333 || true
    net.go:256: Port 33333 is available.
    exec.go:19: [exec] sudo snap set edgex-device-gpio apps.device-gpio.config.edgex-config-provider='none'
    config.go:204: Copying common config file from platform snap to service snap: edgex-device-gpio
    exec.go:19: [exec] sudo cp /snap/edgexfoundry/current/config/core-common-config-bootstrapper/res/configuration.yaml /var/snap/edgex-device-gpio/current/config/common-config.yaml
    exec.go:19: [exec] sudo snap set edgex-device-gpio apps.device-gpio.config.edgex-common-config='/var/snap/edgex-device-gpio/current/config/common-config.yaml'
    exec.go:19: [exec] sudo snap set edgex-device-gpio config.service-port='33333'
    exec.go:19: [exec] sudo snap start --enable edgex-device-gpio.device-gpio
    exec.go:101: [stdout] Started.
    net.go:144: Retry 1/60: Waiting for ports: 33333
    net.go:144: Retry 2/60: Waiting for ports: 33333
    exec.go:19: [exec] sudo snap unset edgex-device-gpio config.service-port
    exec.go:19: [exec] sudo snap restart edgex-device-gpio.device-gpio
    exec.go:101: [stdout] 2023-04-24T12:46:46+02:00 INFO Waiting for "snap.edgex-device-gpio.device-gpio.service" to stop.
    exec.go:101: [stdout] Restarted.
    net.go:144: Retry 1/60: Waiting for ports: 59910 (device-gpio)
    net.go:144: Retry 2/60: Waiting for ports: 59910 (device-gpio)
    exec.go:19: [exec] sudo snap unset edgex-device-gpio config
    exec.go:19: [exec] sudo snap stop --disable edgex-device-gpio.device-gpio
    exec.go:101: [stdout] 2023-04-24T12:46:52+02:00 INFO Waiting for "snap.edgex-device-gpio.device-gpio.service" to stop.
    exec.go:101: [stdout] Stopped.
=== RUN   TestCommon/config/autostart
=== RUN   TestCommon/config/autostart/set_and_unset_global_autostart
    exec.go:19: [exec] sudo snap stop --disable edgex-device-gpio
    exec.go:101: [stdout] Stopped.
    exec.go:19: [exec] snap services edgex-device-gpio | awk 'FNR == 2 {print $2}'
    exec.go:101: [stdout] disabled
    exec.go:19: [exec] snap services edgex-device-gpio | awk 'FNR == 2 {print $3}'
    exec.go:101: [stdout] inactive
    exec.go:19: [exec] sudo snap set edgex-device-gpio autostart='true'
    exec.go:19: [exec] snap services edgex-device-gpio | awk 'FNR == 2 {print $2}'
    exec.go:101: [stdout] enabled
    exec.go:19: [exec] snap services edgex-device-gpio | awk 'FNR == 2 {print $3}'
    exec.go:101: [stdout] active
    exec.go:19: [exec] sudo snap unset edgex-device-gpio autostart
    exec.go:19: [exec] snap services edgex-device-gpio | awk 'FNR == 2 {print $2}'
    exec.go:101: [stdout] enabled
    exec.go:19: [exec] snap services edgex-device-gpio | awk 'FNR == 2 {print $3}'
    exec.go:101: [stdout] active
    exec.go:19: [exec] sudo snap set edgex-device-gpio autostart='false'
    exec.go:19: [exec] snap services edgex-device-gpio | awk 'FNR == 2 {print $2}'
    exec.go:101: [stdout] disabled
    exec.go:19: [exec] snap services edgex-device-gpio | awk 'FNR == 2 {print $3}'
    exec.go:101: [stdout] inactive
    exec.go:19: [exec] sudo snap unset edgex-device-gpio autostart
    exec.go:19: [exec] sudo snap stop --disable edgex-device-gpio
    exec.go:101: [stdout] Stopped.
=== RUN   TestCommon/net
    exec.go:19: [exec] sudo snap start --enable edgex-device-gpio
    exec.go:101: [stdout] Started.
=== RUN   TestCommon/net/ports_open
    net.go:144: Retry 1/60: Waiting for ports: 59910 (device-gpio)
    net.go:144: Retry 2/60: Waiting for ports: 59910 (device-gpio)
=== NAME  TestCommon/net
    net.go:144: Retry 1/60: Waiting for ports: 59910 (device-gpio)
=== RUN   TestCommon/net/ports_not_listening_on_all_interfaces
    exec.go:19: [exec] sudo lsof -nPi :59910 || true
    net.go:264: Looking for '*:59910 (LISTEN)'
=== RUN   TestCommon/net/ports_listening_on_localhost
    exec.go:19: [exec] sudo lsof -nPi :59910 || true
    net.go:264: Looking for '127.0.0.1:59910 (LISTEN)'
=== NAME  TestCommon/net
    exec.go:19: [exec] sudo snap stop --disable edgex-device-gpio
    exec.go:101: [stdout] 2023-04-24T12:47:02+02:00 INFO Waiting for "snap.edgex-device-gpio.device-gpio.service" to stop.
    exec.go:101: [stdout] Stopped.
=== RUN   TestCommon/packaging
=== RUN   TestCommon/packaging/semantic_snap_version
    exec.go:19: [exec] snap info edgex-device-gpio | grep installed | awk '{print $2}'
    exec.go:101: [stdout] 3.0.0-dev.20
--- PASS: TestCommon (46.04s)
    --- PASS: TestCommon/content_interfaces (0.01s)
        --- PASS: TestCommon/content_interfaces/seed_secretstore_token (0.01s)
    --- PASS: TestCommon/config (38.43s)
        --- PASS: TestCommon/config/change_service_port (35.19s)
            --- PASS: TestCommon/config/change_service_port/app_config (13.65s)
            --- PASS: TestCommon/config/change_service_port/global_config (14.32s)
        --- PASS: TestCommon/config/autostart (3.25s)
            --- PASS: TestCommon/config/autostart/set_and_unset_global_autostart (3.25s)
    --- PASS: TestCommon/net (7.26s)
        --- PASS: TestCommon/net/ports_open (1.00s)
        --- PASS: TestCommon/net/ports_not_listening_on_all_interfaces (0.13s)
        --- PASS: TestCommon/net/ports_listening_on_localhost (0.12s)
    --- PASS: TestCommon/packaging (0.34s)
        --- PASS: TestCommon/packaging/semantic_snap_version (0.34s)
PASS
2023/04/24 12:47:07 [TEARDOWN]
2023/04/24 12:47:07 [exec] (sudo journalctl --since "2023-04-24 12:45:44" --no-pager | grep "edgex-device-gpio"|| true) > edgex-device-gpio.log
Wrote snap logs to /home/mengyi/Desktop/edgex400/edgex-snap-testing/test/suites/device-gpio/edgex-device-gpio.log
2023/04/24 12:47:08 [exec] (sudo journalctl --since "2023-04-24 12:45:44" --no-pager | grep "edgexfoundry"|| true) > edgexfoundry.log
Wrote snap logs to /home/mengyi/Desktop/edgex400/edgex-snap-testing/test/suites/device-gpio/edgexfoundry.log
2023/04/24 12:47:08 Removing installed snap: true
2023/04/24 12:47:08 [exec] sudo snap remove --purge edgex-device-gpio
2023/04/24 12:47:12 [stdout] edgex-device-gpio removed
2023/04/24 12:47:12 [exec] sudo snap remove --purge edgexfoundry
2023/04/24 12:47:13 [stdout] 2023-04-24T12:47:13+02:00 INFO Waiting for "snap.edgexfoundry.core-data.service" to stop.
2023/04/24 12:47:14 [stdout] 2023-04-24T12:47:14+02:00 INFO Waiting for "snap.edgexfoundry.support-scheduler.service" to stop.
2023/04/24 12:47:15 [stdout] 2023-04-24T12:47:15+02:00 INFO Waiting for "snap.edgexfoundry.support-notifications.service" to stop.
2023/04/24 12:47:16 [stdout] 2023-04-24T12:47:16+02:00 INFO Waiting for "snap.edgexfoundry.core-metadata.service" to stop.
2023/04/24 12:47:20 [stdout] edgexfoundry removed
ok      edgex-snap-testing/test/suites/device-gpio      98.393s
```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->